### PR TITLE
New flag: read-buffer-size

### DIFF
--- a/filtron.go
+++ b/filtron.go
@@ -17,6 +17,7 @@ func main() {
 	listen := flag.String("listen", "127.0.0.1:4004", "Proxy listen address")
 	apiAddr := flag.String("api", "127.0.0.1:4005", "API listen address")
 	ruleFile := flag.String("rules", "rules.json", "JSON rule list")
+	readBufferSize := flag.Int("read-buffer-size", 16*1024, "Read buffer size")
 	printVersionInfo := flag.Bool("version", false, "Version information")
 	flag.Parse()
 
@@ -31,6 +32,6 @@ func main() {
 		return
 	}
 	log.Println(rule.RulesLength(rules), "rules loaded from", *ruleFile)
-	p := proxy.Listen(*listen, *target, &rules)
+	p := proxy.Listen(*listen, *target, *readBufferSize, &rules)
 	api.Listen(*apiAddr, *ruleFile, p)
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -21,11 +21,11 @@ type Proxy struct {
 	client           *fasthttp.HostClient
 }
 
-func Listen(address, target string, rules *[]*rule.Rule) *Proxy {
+func Listen(address, target string, readBufferSize int, rules *[]*rule.Rule) *Proxy {
 	p := &Proxy{
 		NumberOfRequests: 0,
 		Rules:            rules,
-		client:           &fasthttp.HostClient{Addr: target, ReadBufferSize: 4096 * 4},
+		client:           &fasthttp.HostClient{Addr: target, ReadBufferSize: readBufferSize},
 	}
 	go func(address string, p *Proxy) {
 		log.Println("Proxy listens on", address)


### PR DESCRIPTION
Make `ReadBufferSize` configurable from command line. Default value is 16k.