### PR TITLE
[experimental / unfinished]

### DIFF
--- a/filtron.go
+++ b/filtron.go
@@ -17,6 +17,7 @@ func main() {
 	listen := flag.String("listen", "127.0.0.1:4004", "Proxy listen address")
 	apiAddr := flag.String("api", "127.0.0.1:4005", "API listen address")
 	ruleFile := flag.String("rules", "rules.json", "JSON rule list")
+	debug := flag.Bool("debug", false, "Log debug information")
 	readBufferSize := flag.Int("read-buffer-size", 16*1024, "Read buffer size")
 	printVersionInfo := flag.Bool("version", false, "Version information")
 	flag.Parse()
@@ -32,6 +33,6 @@ func main() {
 		return
 	}
 	log.Println(rule.RulesLength(rules), "rules loaded from", *ruleFile)
-	p := proxy.Listen(*listen, *target, *readBufferSize, &rules)
+	p := proxy.Listen(*listen, *target, *readBufferSize, &rules, *debug)
 	api.Listen(*apiAddr, *ruleFile, p)
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -19,16 +19,19 @@ type Proxy struct {
 	NumberOfRequests uint
 	Rules            *[]*rule.Rule
 	client           *fasthttp.HostClient
+	debug            bool
 }
 
-func Listen(address, target string, readBufferSize int, rules *[]*rule.Rule) *Proxy {
+func Listen(address, target string, readBufferSize int, rules *[]*rule.Rule, debug bool) *Proxy {
 	p := &Proxy{
 		NumberOfRequests: 0,
 		Rules:            rules,
 		client:           &fasthttp.HostClient{Addr: target, ReadBufferSize: readBufferSize},
+		debug:            debug,
 	}
 	go func(address string, p *Proxy) {
 		log.Println("Proxy listens on", address)
+		log.Println("Target on", target)
 		fasthttp.ListenAndServe(address, p.Handler)
 	}(address, p)
 	return p
@@ -54,7 +57,7 @@ func (p *Proxy) Handler(ctx *fasthttp.RequestCtx) {
 	err := p.client.Do(appRequest, resp)
 	if err != nil {
 		log.Println("Response error:", err, resp)
-		ctx.SetStatusCode(429)
+		ctx.SetStatusCode(500)
 		return
 	}
 

--- a/selector/selector.go
+++ b/selector/selector.go
@@ -81,5 +81,6 @@ func (s *Selector) Match(ctx *fasthttp.RequestCtx) (string, bool) {
 	if s.Negate {
 		found = !found
 	}
+	log.Println(" * ", s.RequestAttr, "[", s.SubAttr, "]=", string(matchSlice), ";", s.Regexp, "negate=", s.Negate, "found=", found)
 	return string(matchSlice), found
 }


### PR DESCRIPTION
* limit is per aggregation instead of being global: it requires more memory and GC to remove old entries (see ```func (r *Rule) EraseOldAggregationValues()```, unfinished there is no scheduled call to this function)
* Aggregation: selector list are combined with an AND instead of an OR (see ```func (r *Rule) Match(ctx *fasthttp.RequestCtx) bool```)