### PR TITLE
`go get` -> `go install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Reverse HTTP proxy to filter requests by different rules.
 Can be used between production webserver and the application server to prevent abuse of the application backend.
 
-The original purpose of this program was to defend [searx](https://asciimoo.github.com/searx/), but it can be used to guard any web application.
+The original purpose of this program was to defend [searx](https://asciimoo.github.io/searx/), but it can be used to guard any web application.
 
 
 ## Installation and setup

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The original purpose of this program was to defend [searx](https://asciimoo.gith
 ## Installation and setup
 
 ```
-$ go get github.com/asciimoo/filtron
+$ go install github.com/asciimoo/filtron
 $ "$GOPATH/bin/filtron" --help
 ```
 


### PR DESCRIPTION
Since the functionality of `go get` was moved to `go install`, running the `go get` command in README.md won't build and install filtron, like it used to.