### PR TITLE
fix: 'go install' requires a version when current directory is not in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The original purpose of this program was to defend [searx](https://asciimoo.gith
 ## Installation and setup
 
 ```
-$ go install github.com/asciimoo/filtron
+$ go install github.com/asciimoo/filtron@latest
 $ "$GOPATH/bin/filtron" --help
 ```
 


### PR DESCRIPTION
Update `go install` command line to fix error:

`go: 'go install' requires a version when current directory is not in a module`.